### PR TITLE
Method addColumnForCycle throws error if time is not the first column

### DIFF
--- a/python/tests/ts/test_dataframe.py
+++ b/python/tests/ts/test_dataframe.py
@@ -120,6 +120,46 @@ class TestDataframe(BASE):
             "with key 7"
         )
 
+    def test_addColumnsForCycleTimeNotFirst(self):
+        import pyspark.sql.types as pyspark_types
+        price = self.flintContext.read.pandas(test_utils.make_pdf([
+            [7, 1000, 0.5],
+            [3, 1000, 1.0],
+            [3, 1050, 1.5],
+            [7, 1050, 2.0],
+            [3, 1100, 2.5],
+            [7, 1100, 3.0],
+            [3, 1150, 3.5],
+            [7, 1150, 4.0],
+            [3, 1200, 4.5],
+            [7, 1200, 5.0],
+            [3, 1250, 5.5],
+            [7, 1250, 6.0],
+        ], ["id", "time", "price"]))
+        expected_pdf = test_utils.make_pdf([
+            [1000, 7, 0.5, 1.0],
+            [1000, 3, 1.0, 2.0],
+            [1050, 3, 1.5, 3.0],
+            [1050, 7, 2.0, 4.0],
+            [1100, 3, 2.5, 5.0],
+            [1100, 7, 3.0, 6.0],
+            [1150, 3, 3.5, 7.0],
+            [1150, 7, 4.0, 8.0],
+            [1200, 3, 4.5, 9.0],
+            [1200, 7, 5.0, 10.0],
+            [1250, 3, 5.5, 11.0],
+            [1250, 7, 6.0, 12.0],
+        ], ["time", "id", "price", "adjustedPrice"])
+
+        def fn_1(rows):
+            size = len(rows)
+            return {row: row.price*size for row in rows}
+
+        new_pdf = price.addColumnsForCycle(
+            {"adjustedPrice": (pyspark_types.DoubleType(), fn_1)}
+        ).toPandas()
+        test_utils.assert_same(new_pdf, expected_pdf)
+
     def test_merge(self):
         price = self.price()
         price1 = price.filter(price.time > 1100)

--- a/python/ts/flint/dataframe.py
+++ b/python/ts/flint/dataframe.py
@@ -308,12 +308,12 @@ class TimeSeriesDataFrame(pyspark.sql.DataFrame):
         :returns: a new dataframe with the columns added
         :rtype: :class:`TimeSeriesDataFrame`
         """
-        # Need to make a new StructType to prevent from modifying the original schema object
-        schema = pyspark_types.StructType.fromJson(self.schema.jsonValue())
         tsdf = self.groupByCycle(key)
-        # Don't pickle the whole schema, just the names for the lambda
+        # Last element of tsdf.schema describes the 'rows' returned
+        # which does differ from self.schema if the first column is not 'time'
+        schema = tsdf.schema[len(tsdf.schema)-1].dataType.elementType
         schema_names = list(schema.names)
-
+        
         def flatmap_fn():
             def _(orig_row):
                 orig_rows = orig_row.rows


### PR DESCRIPTION
If time is not the first column an error was thrown. 
This is a workaround that has the side effects of sometimes re-ordering the existing columns, but the newly added column will be the last.