### PR TITLE
Remove time unit and column from python and make time the first column

### DIFF
--- a/python/ts/flint/dataframe.py
+++ b/python/ts/flint/dataframe.py
@@ -301,10 +301,10 @@ class TimeSeriesDataFrame(pyspark.sql.DataFrame):
         :returns: a new dataframe with the columns added
         :rtype: :class:`TimeSeriesDataFrame`
         """
-        # Need to make a new StructType to prevent from modifying the original schema object
-        schema = pyspark_types.StructType.fromJson(self.schema.jsonValue())
         tsdf = self.groupByCycle(key)
-        # Don't pickle the whole schema, just the names for the lambda
+        # Last element of tsdf.schema describes the 'rows' returned
+        # which does differ from self.schema if the first column is not 'time'
+        schema = tsdf.schema[len(tsdf.schema)-1].dataType.elementType
         schema_names = list(schema.names)
 
         def flatmap_fn():

--- a/python/ts/flint/readwriter.py
+++ b/python/ts/flint/readwriter.py
@@ -15,7 +15,6 @@
 #
 
 from pyspark.sql import DataFrame
-from pyspark.sql.readwriter import DataFrameReader, DataFrameWriter
 
 from . import java
 from . import utils
@@ -57,9 +56,7 @@ class TSDataFrameReader(object):
 
         return TimeSeriesDataFrame._from_pandas(
             df, schema, self._flintContext._sqlContext,
-            time_column=time_column,
-            is_sorted=is_sorted,
-            unit=unit)
+            is_sorted=is_sorted)
 
     def _df_between(self, df, begin, end, time_column, unit):
         """Filter a Python dataframe to contain data between begin (inclusive) and end (exclusive)


### PR DESCRIPTION
This PR addresses issue #8 and issue #9.
The time_column and unit arguments have been removed from the TimeSeriesDataFrame python constructor.
If the time column is not the first column it is moved to be the first column of the result. This behavior was already enforced in Scala and is now properly handled in Python including the code that caused issue #8. 