### PR TITLE
fix fromNormalizedSortedRDD range split array indexes

### DIFF
--- a/src/main/scala/com/twosigma/flint/rdd/Conversion.scala
+++ b/src/main/scala/com/twosigma/flint/rdd/Conversion.scala
@@ -20,6 +20,7 @@ import com.twosigma.flint.hadoop._
 import org.apache.spark.rdd.RDD
 import org.apache.spark._
 
+import scala.collection.SortedMap
 import scala.collection.immutable.TreeMap
 import scala.reflect.ClassTag
 
@@ -134,7 +135,7 @@ object Conversion {
         Iterator(if (iter.nonEmpty) Map(index -> iter.next._1) else Map[Int, K]())
     }.reduce(_ ++ _)
 
-    val indexMapping = partitionToFirstKey.toSeq.sortBy(_._1).zipWithIndex.map(_.swap).toMap
+    val indexMapping = SortedMap[Int, (Int, K)]() ++ partitionToFirstKey.toSeq.sortBy(_._1).zipWithIndex.map(_.swap)
 
     val rangeSplits = indexMapping.map {
       case (idx, (parentIdx, begin)) =>
@@ -142,7 +143,7 @@ object Conversion {
           case (idx2, _) => partitionToFirstKey.get(idx2)
         }
         RangeSplit(OrderedRDDPartition(idx).asInstanceOf[Partition], CloseOpen(begin, end))
-    }.toArray.sortBy(_.partition.index)
+    }.toArray
 
     val indexToParentPartition = indexMapping.map {
       case (idx, (parentIdx, _)) => (idx, rdd.partitions(parentIdx))

--- a/src/main/scala/com/twosigma/flint/rdd/Conversion.scala
+++ b/src/main/scala/com/twosigma/flint/rdd/Conversion.scala
@@ -142,7 +142,7 @@ object Conversion {
           case (idx2, _) => partitionToFirstKey.get(idx2)
         }
         RangeSplit(OrderedRDDPartition(idx).asInstanceOf[Partition], CloseOpen(begin, end))
-    }.toArray
+    }.toArray.sortBy(_.partition.index)
 
     val indexToParentPartition = indexMapping.map {
       case (idx, (parentIdx, _)) => (idx, rdd.partitions(parentIdx))

--- a/src/test/scala/com/twosigma/flint/rdd/ConversionSpec.scala
+++ b/src/test/scala/com/twosigma/flint/rdd/ConversionSpec.scala
@@ -70,6 +70,7 @@ class ConversionSpec extends FlatSpec with SharedSparkContext with Timeouts {
     assert(sortedRDDWithEmptyPartitions.getNumPartitions == 10)
 
     val orderedRdd = Conversion.fromNormalizedSortedRDD(sortedRDDWithEmptyPartitions)
+    assert(orderedRdd.collect.length == sortedData.length)
     assert(orderedRdd.getNumPartitions == 8)
   }
 


### PR DESCRIPTION
This fixes a bug in the Conversion.fromNormalizedSortedRDD. Currently rangeSplits are generated from a map (partitionId -> (parentPartitionId, K)). The ordering of the keys in the map is not guaranteed so the array of RangeSplits does not contain sorted OrderedRDDPartitions. Therefore, using the partitionId to get the range split from the rangeSplits array will return an arbitrary range split causing errors during range validation. 

I modified the test for it so that the bug can be reproduced if the fix is not present. 

Here the solution is to sort the range split array by the id of the partition. This is a minor fix so I didn't send in a contributor agreement thingy.