### PR TITLE
Add top-level "ts" package to list of packages in setup.py

### DIFF
--- a/python/setup.py
+++ b/python/setup.py
@@ -18,13 +18,12 @@ from setuptools import setup
 
 import versioneer
 
-
 setup(
     name='ts-flint',
     description='Distributed time-series analysis on Spark',
     author='Li Jin, Leif Walsh',
     author_email='ljin@twosigma.com, leif@twosigma.com',
-    packages=['ts.flint'],
+    packages=['ts', 'ts.flint'],
     setup_requires=[
     ],
     install_requires=[


### PR DESCRIPTION
- Without this, the wheel file produced by this will not place an
  __init__.py file underneath the "ts" directory
- The fix allows imports to work normally